### PR TITLE
Fix bug where using `abstract` in a name broke indents

### DIFF
--- a/blitzmax-mode.el
+++ b/blitzmax-mode.el
@@ -83,7 +83,7 @@
   (concat
    "^[\t ]*\\([Mm]ethod\\|[Ff]unction\\)"
    "[ \t ]+\\(\\w+\\)[ \t ]*(?"
-   ".*[Aa]bstract"))
+   ".*[ \t]+[Aa]bstract"))
 
 (defconst blitzmax-mode-extern-start-regexp
   "^[\t ]*[Ee]xtern")

--- a/test/blitzmax-mode-indentation-test.el
+++ b/test/blitzmax-mode-indentation-test.el
@@ -104,5 +104,10 @@
    ("issue_004_b.bmx" :indent t)
    (should (string= (cleaned-buffer-string) (fixture "issue_004_b.bmx")))))
 
+;; Returning a name with `Abstract` in it breaks indentation
+(ert-deftest blitzmax-mode-indentation-test/issue-006-abstract-type-indentation ()
+  (with-blitzmax-mode-test
+   ("issue_006.bmx" :indent t)
+   (should (string= (cleaned-buffer-string) (fixture "issue_006.bmx")))))
 
 ;;; blitzmax-mode-indentation-test.el ends here

--- a/test/fixtures/issue_006.bmx
+++ b/test/fixtures/issue_006.bmx
@@ -1,0 +1,22 @@
+' Issue 006 - Functions that return types with `Abstract` in the name are not indented properly
+
+Type MyType
+
+    Function returnType:AbstractType()
+        ' Should indent one level
+    End Function
+
+    Function doAbstractThings()
+        ' Should also indent one level
+    End Function
+
+
+    Method returnAType:AbstractType()
+        ' Should indent one level
+    End Method
+
+    Method doAbstractThingsMethod()
+        ' Should also indent one level
+    End Method
+
+End Type


### PR DESCRIPTION
Fixes issue #6 