### PR TITLE
Fix indentation issue with Repeat...Forever

### DIFF
--- a/blitzmax-mode.el
+++ b/blitzmax-mode.el
@@ -103,14 +103,14 @@
 (defconst blitzmax-mode-case-regexp "^[ \t]*\\([Cc]ase\\|[Dd]efault\\)")
 (defconst blitzmax-mode-select-end-regexp "^[ \t]*[Ee]nd[ \t]*[Ss]elect")
 
-(defconst blitzmax-mode-for-regexp "^[ \t]*[Ff]or")
+(defconst blitzmax-mode-for-regexp "^[ \t]*[Ff]or[ \t]+[[:alnum:]]+")
 (defconst blitzmax-mode-next-regexp "^[ \t]*[Nn]ext")
 
 (defconst blitzmax-mode-while-regexp "^[ \t]*[Ww]hile")
 (defconst blitzmax-mode-wend-regexp "^[ \t]*[Ww]end")
 
 (defconst blitzmax-mode-repeat-regexp "^[ \t]*[Rr]epeat")
-(defconst blitzmax-mode-until-regexp "^[ \t]*[Uu]ntil")
+(defconst blitzmax-mode-until-regexp "^[ \t]*\\([Ff]orever\\|[Uu]ntil\\)")
 
 (defconst blitzmax-mode-blank-regexp "^[ \t]*$")
 (defconst blitzmax-mode-comment-regexp "^[ \t]*\\s<.*$")

--- a/test/blitzmax-mode-indentation-test.el
+++ b/test/blitzmax-mode-indentation-test.el
@@ -60,6 +60,9 @@
 (ert-deftest blitzmax-mode-indentation-test/repeat-until ()
   (test-blitzmax-mode-indentation "repeat_until.bmx"))
 
+(ert-deftest blitzmax-mode-indentation-test/repeat-forever ()
+  (test-blitzmax-mode-indentation "repeat_forever.bmx"))
+
 
 ;; --------------------------------------------------
 ;; -- Bugs

--- a/test/fixtures/repeat_forever.bmx
+++ b/test/fixtures/repeat_forever.bmx
@@ -1,0 +1,14 @@
+' Simple Repeat loop
+Repeat
+    ' Do this
+Forever
+' Not indented
+
+' Nested Repeat with mixed cases
+Repeat
+    Repeat
+        repeat
+        forever
+    Forever
+Forever
+' Not indented.


### PR DESCRIPTION
Fixes issue #16.

Was missing regexp for `Forever` keyword.

Also had to fix the regexp for finding "For...Next" loops. It was treating the
first three letters of `Forever` as a new `For` loop and indenting incorrectly.